### PR TITLE
Change visible duration of graph

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,7 +24,7 @@ def get_influxdb_data(duration):
     ## Query data as pandas dataframe
     df = query_api.query_data_frame('from(bucket:"co2")'
                                     f'|> range(start: -{duration})'
-                                    '|> filter(fn: (r) => r.host == "af1ae06960bff131b214d73d7747d3b5")'
+                                    '|> filter(fn: (r) => r.host == "6cb1b8e43a19bdb3950a118a36af3452")'
                                     '|> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")'
                                     '|> keep(columns: ["co2", "temperature", "humidity", "lat", "lon", "alt", "_time"])')
     return df.drop(['result', 'table'], axis=1)
@@ -47,16 +47,15 @@ def serve_layout():
         }),
 
         html.H3('Sensor Data'),
-        dcc.Graph(id='co2_graph', figure=co2_fig),
-        dcc.Interval(id='interval', interval=60*1000, n_intervals=0),
-        html.Div(id='timezone', hidden=True),
-
         dcc.Dropdown(id='duration', value='1h', options=[
             {'label': '10 minutes', 'value': '10m'},
             {'label': '30 minutes', 'value': '30m'},
             {'label': '1 hour',     'value': '1h'},
             {'label': '1 day',      'value': '24h'},
         ]),
+        dcc.Graph(id='co2_graph', figure=co2_fig),
+        dcc.Interval(id='interval', interval=60*1000, n_intervals=0),
+        html.Div(id='timezone', hidden=True),
         html.Div([html.Button('Export as CSV', id='export'), dcc.Download(id='download')]),
     ])
 

--- a/app.py
+++ b/app.py
@@ -13,28 +13,30 @@ import plotly.graph_objects as go
 external_stylesheets = ['https://codepen.io/chriddyp/pen/bWLwgP.css']
 
 # Dash App
-app = dash.Dash(__name__, title='GHG Cloud', external_stylesheets=external_stylesheets, prevent_initial_callbacks=True)
+app = dash.Dash(__name__, title='GHG Cloud', external_stylesheets=external_stylesheets)
 server = app.server
 
 # Connect to InfluxDB
 client = InfluxDBClient.from_config_file("influx_config.ini")
 query_api = client.query_api()
 
-def get_influxdb_data():
+def get_influxdb_data(duration):
     ## Query data as pandas dataframe
-    df = query_api.query_data_frame('from(bucket:"co2") '
-                                    '|> range(start: -1h) '
-                                    '|> filter(fn: (r) => r.host == "6cb1b8e43a19bdb3950a118a36af3452")'
-                                    '|> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") '
+    df = query_api.query_data_frame('from(bucket:"co2")'
+                                    f'|> range(start: -{duration})'
+                                    '|> filter(fn: (r) => r.host == "af1ae06960bff131b214d73d7747d3b5")'
+                                    '|> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")'
                                     '|> keep(columns: ["co2", "temperature", "humidity", "lat", "lon", "alt", "_time"])')
     return df.drop(['result', 'table'], axis=1)
 
 def serve_layout():
     #Define this function to query new data on page load
     return html.Div([
+        html.Div(id='onload', hidden=True),
+
         html.H1("Ribbit Network"),
-        html.A(html.Button('Learn More!'),
-            href='https://ribbitnetwork.org/'),
+        html.A(html.Button('Learn More!'), href='https://ribbitnetwork.org/'),
+
         html.H3('Sensor Map'),
         dcc.Graph(
             id='co2_globe',
@@ -43,26 +45,23 @@ def serve_layout():
             "width": "100%",
             'display': 'inline-block'
         }),
+
         html.H3('Sensor Data'),
-        dcc.Graph(
-            id='co2_graph',
-            figure=co2_fig),
-        dcc.Interval(
-            id='interval-component',
-            interval=60*1000, # in milliseconds
-            n_intervals=0),
+        dcc.Graph(id='co2_graph', figure=co2_fig),
+        dcc.Interval(id='interval', interval=60*1000, n_intervals=0),
+        html.Div(id='timezone', hidden=True),
+
+        dcc.Dropdown(id='duration', value='1h', options=[
+            {'label': '10 minutes', 'value': '10m'},
+            {'label': '30 minutes', 'value': '30m'},
+            {'label': '1 hour',     'value': '1h'},
+            {'label': '1 day',      'value': '24h'},
+        ]),
         html.Div([html.Button('Export as CSV', id='export'), dcc.Download(id='download')]),
-        html.Div(id='timezone', hidden=True)
     ])
 
-@app.callback(Output('download', 'data'), Input('export', 'n_clicks'))
-def export_data(n_clicks):
-    df = get_influxdb_data()
-    df.columns = ['Timestamp', 'Altitude', 'CO2', 'Humidity', 'Latitude', 'Longitude', 'Temperature']
-    return dcc.send_data_frame(df.to_csv, index=False, filename='data.csv')
-
 ## Query data as pandas dataframe
-co2_fig = px.line(get_influxdb_data(), x="_time", y="co2", title="Co2 PPM")
+co2_fig = px.line(get_influxdb_data('1h'), x="_time", y="co2", title="Co2 PPM")
 
 # Only get the latest point for displaying on the map
 map_df = query_api.query_data_frame('from(bucket:"co2") '
@@ -100,15 +99,31 @@ app.clientside_callback(
     }
     ''',
     Output('timezone', 'children'),
-    Input('interval-component', 'n_intervals')
+    Input('onload', 'children'),
 )
 
 # Update CO2 graph
-@app.callback(Output('co2_graph', 'figure'), Input('timezone', 'children'))
-def update_graph(timezone):
-    df = get_influxdb_data()
+@app.callback(
+    Output('co2_graph', 'figure'),
+    [
+        Input('timezone', 'children'),
+        Input('duration', 'value'),
+        Input('interval', 'n_intervals'),
+    ],
+)
+def update_graph(timezone, duration, n_intervals):
+    df = get_influxdb_data(duration)
     df['_time'] = df['_time'].dt.tz_convert(timezone)
     return px.line(df, x="_time", y="co2", title="Co2 PPM")
+
+# Export data as CSV
+@app.callback(Output('download', 'data'), [Input('export', 'n_clicks'), Input('duration', 'value')])
+def export_data(n_clicks, duration):
+    if n_clicks == None:
+        return
+    df = get_influxdb_data(duration)
+    df.columns = ['Timestamp', 'Altitude', 'CO2', 'Humidity', 'Latitude', 'Longitude', 'Temperature']
+    return dcc.send_data_frame(df.to_csv, index=False, filename='data.csv')
 
 if __name__ == '__main__':
     app.run_server(debug=True)


### PR DESCRIPTION
Closes #6

Supports the following durations: 10m, 30m, 1h, and 24h (based on https://www.purpleair.com/map)

The 24h duration is slow to load (lots of data), so we might want to sample one data point every minute (instead of every second, or whatever the current interval is)