### PR TITLE
Check type after db query for get_map_data()

### DIFF
--- a/db.py
+++ b/db.py
@@ -6,13 +6,16 @@ client = InfluxDBClient.from_config_file('influx_config.ini')
 query_api = client.query_api()
 
 
-def get_map_data():
+def get_map_data() -> list[pd.DataFrame]:
     df = query_api.query_data_frame('from(bucket:"co2")'
                                     '|> range(start:-15m)'
                                     '|> limit(n:1)'
                                     '|> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")'
                                     '|> keep(columns: ["host", "lat", "lon", "co2"])')
-    return pd.concat(df)
+    if type(df) is list:
+        return pd.concat(df)
+    if type(df) is pd.DataFrame:
+        return df
 
 
 def get_sensor_data(host, duration):

--- a/db.py
+++ b/db.py
@@ -6,7 +6,7 @@ client = InfluxDBClient.from_config_file('influx_config.ini')
 query_api = client.query_api()
 
 
-def get_map_data() -> list[pd.DataFrame]:
+def get_map_data() -> pd.DataFrame:
     df = query_api.query_data_frame('from(bucket:"co2")'
                                     '|> range(start:-15m)'
                                     '|> limit(n:1)'


### PR DESCRIPTION
This is addressing issue #50.

When the query to the db returns more than one table, these are returned as a list of pd.DataFrames, which were then concatenated with pd.concat(df). However, sometimes the db only returns a single table (possibly when only one sensor on the network has posted new observations?) and pd.concat() fails when given a single pd.DataFrame rather than a list.

I've added a type hint to the get_map_data() function, and only concatenate if we indeed have a list.