### PR TITLE
Add minZoom limit and max lat/lon bounds to fix infinite scrolling

### DIFF
--- a/app.py
+++ b/app.py
@@ -60,6 +60,8 @@ def serve_layout():
                 id='map',
                 center=(b_box_lat, b_box_lon),
                 zoom=zoom,
+                minZoom=3,
+                maxBounds=[[-75, -180],[75, 180]],
             ),
         ], id='map-container'),
 

--- a/app.py
+++ b/app.py
@@ -61,7 +61,7 @@ def serve_layout():
                 center=(b_box_lat, b_box_lon),
                 zoom=zoom,
                 minZoom=3,
-                maxBounds=[[-75, -180],[75, 180]],
+                maxBounds=[[-75, -180],[75, 200]],
             ),
         ], id='map-container'),
 


### PR DESCRIPTION
This is to address issue #60 

The lat bounds keep the view within 75 south and 75 north latitudes (If we get someone placing a frog sensor near the poles later we can change this!) largely because the Mercator projection gives the poles too much area in the map. The lon bounds prevent the horizontal infinite scrolling issue (limiting the map to a single instance of -180 to 180 lon).

The min zoom out limit also helps guide the user to which side of the map to scroll towards (e.g. don't try to scroll east past 180 lon across the Pacific to go from Asia to the Americas, scroll around west to see there)