### PR TITLE
Add sampling frequency options

### DIFF
--- a/assets/index.css
+++ b/assets/index.css
@@ -50,9 +50,16 @@ body {
     width: 160px;
 }
 
-#controls #duration {
+#controls #duration, #frequency {
     margin-right: 8px;
     width: 160px;
+}
+
+
+#controls #durationLabel, #frequencyLabel {
+	margin-right: 8px;
+    font-weight: bold;
+	text-align: center;
 }
 
 #controls #export {

--- a/assets/index.css
+++ b/assets/index.css
@@ -12,6 +12,8 @@ body {
     display: flex;
     height: 40px;
     padding: 16px 32px 16px 16px;
+	width: 70%;
+	margin: 0 auto;
 }
 
 #nav img {
@@ -23,7 +25,8 @@ body {
     display: flex;
     height: 400px;
     justify-content: center;
-    width: 100%;
+	width: 70%;
+	margin: 0 auto;
 }
 
 #map-container #loading {
@@ -38,6 +41,8 @@ body {
 #controls {
     display: flex;
     margin: 16px;
+	width: 70%;
+    margin: 16px auto;
 }
 
 #controls #host {

--- a/db.py
+++ b/db.py
@@ -19,11 +19,15 @@ def get_map_data() -> pd.DataFrame:
         return df
 
 
-def get_sensor_data(host, duration):
+def get_sensor_data(host, duration, frequency=None):
     df = query_api.query_data_frame('from(bucket:"co2")'
                                     f'|> range(start: -{duration})'
                                     f'|> filter(fn: (r) => r.host == "{host}")'
                                     '|> aggregateWindow(every: 1m, fn: mean, createEmpty: false)'
                                     '|> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")'
                                     '|> keep(columns: ["co2", "temperature", "humidity", "lat", "lon", "alt", "_time", "baro_pressure"])')
-    return df.drop(['result', 'table'], axis=1)
+    df.drop(['result', 'table'], axis=1, inplace=True)
+    if frequency in ['5min', '10min', '15min', '30min', '1h']:
+        df.set_index('_time', inplace=True)
+        df = df.resample(frequency).mean().reset_index()
+    return df


### PR DESCRIPTION
Addressing #31 

I've added a sampling frequency options of 1 minute (instantaneous samples), 5, 15, 30 minutes, and 1 hour (averaged over that time period). I did this by adding an optional resampling step within _db.get_sensor_data()_, and a second dropdown menu on the dashboard. The sampling frequency option selected is also reflected in the data.csv download. I also changed the default duration and sampling to 7 days and 1 hour respectively, just because I thought it looked more interesting than the "noisy" instantaneous data.

Other minor changes in this pull request:
* cosmetic changes to map dashboard (map width, dropdown menu labels, map marker size)
* dataframe key cleanup (removed subscript and degree symbol from dataframe column names)