### PR TITLE
remove shared-xaxes to set time on each table; update README with an …

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ python3 -m pip install -r requirements.txt
 python3 app.py
 ```
 
-On Windows (If using Git Bash)
+In the case you may have recently installed or upgraded python, you might run the app but encounter a local issuer certificate error.  If you do encounter this, run the Install Certificates.command file in your Python folder (see [this issue](https://github.com/Ribbit-Network/ribbit-network-dashboard/issues/98) for more details).
+
 ```
 python3 -m venv env
 env/Scripts/activate

--- a/app.py
+++ b/app.py
@@ -198,16 +198,16 @@ def update_graphs(sensor_data: list, sensor: Optional[str], _n_intervals) -> Uni
         return html.P('No data available for this sensor in the selected time range.')
 
     columns_to_plot = ['CO2 (PPM)', 'Temperature (degC)', 'Barometric Pressure (mBar)', 'Humidity (%)']
-    fig = make_subplots(rows=4, cols=1, shared_xaxes=True)
+    fig = make_subplots(rows=4, cols=1)
     for ind, col in enumerate(columns_to_plot):
-        fig.add_scatter(x=sensor_data["Time"], 
-                        y=sensor_data[col], 
-                        mode="lines", 
-                        line=go.scatter.Line(color="black"), 
-                        showlegend=False, 
-                        row=ind+1, 
-                        col=1, 
-                        hovertemplate="Time: %{x}<br>%{text}: %{y:.2f}<extra></extra>", 
+        fig.add_scatter(x=sensor_data["Time"],
+                        y=sensor_data[col],
+                        mode="lines",
+                        line=go.scatter.Line(color="black"),
+                        showlegend=False,
+                        row=ind+1,
+                        col=1,
+                        hovertemplate="Time: %{x}<br>%{text}: %{y:.2f}<extra></extra>",
                         text=[col]*len(sensor_data[col]))
         fig.update_yaxes(title_text=col, row=ind+1, col=1)
     fig.update_layout(template="plotly_white", height=1200)


### PR DESCRIPTION
As noted in the [issue for this PR](https://github.com/Ribbit-Network/ribbit-network-dashboard/issues/98), this is just removing the shared_xaxes parameter that set all graphs to share one time x axis.  Removing that installs the x axis for each graph.

I also updated the README to help those of us less savvy with python installations, who might hit a issuer cert error.