### PR TITLE
Pin protobuf to 3.20.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ jsbeautifier==1.14.4
 MarkupSafe==2.1.1
 pandas==1.4.3
 plotly==5.9.0
-protobuf==3.20.*
+protobuf==3.20.1
 python-dateutil==2.8.2
 pytz==2022.1
 Rx==3.2.0


### PR DESCRIPTION
Pinning protobuf version to 3.20.1 as this was previously undefined.